### PR TITLE
Fix Jekyll startup issue due to recent changes with Minimal Mistake theme

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -13,4 +13,5 @@ group :jekyll_plugins do
   gem "jekyll-feed"
   gem "jemoji"
   gem "jekyll-algolia"
+  gem "jekyll-include-cache"
 end

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,6 +7,7 @@
 
 remote_theme             : "mmistakes/minimal-mistakes"
 
+
 minimal_mistakes_skin    : "von" # "default", "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
 
 # Site Settings
@@ -263,6 +264,7 @@ plugins:
   - jekyll-gist
   - jekyll-feed
   - jemoji
+  - jekyll-include-cache
 
 # mimic GitHub Pages with --safe
 whitelist:


### PR DESCRIPTION
Hey @swcurran!

Jekyll started running into some issues loading Minimal Mistakes via `remote_theme`, so I've made a small fix to our Gemfiles as suggested here: https://github.com/mmistakes/minimal-mistakes/issues/1875

Since this is a remote theme that's actively being worked on, it may be worth noting that similar issues can be prevented in the future if we specified a specific version of the theme, like this:

`remote_theme: "mmistakes/minimal-mistakes@4.13.0"`

... then manually upgrading to newer versions as you see fit (as suggested by the [theme's maintainer](https://github.com/mmistakes/minimal-mistakes/issues/1875#issuecomment-427348130)). I haven't done that here, but I thought I'd give you a heads up in case you'd like to make this change.

Thanks!