### PR TITLE
Add project lifecycle badge, license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![img](https://img.shields.io/badge/Lifecycle-Stable-97ca00)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
+[![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-blue.svg)](https://creativecommons.org/licenses/by/4.0/)
+
 # VON
 
 The Verifiable Organizations Network (VON)


### PR DESCRIPTION
Resolves #368 

Added license badge, project lifecycle badge.
For lifecycle badge information, see: https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md

License badge matches what is in the license file, it is different than the other repos we have (CC4.0 here, Apache everywhere else) so I wanted to make sure it is still correct and it does not need updating.