### PR TITLE
Remove Fathom tracker, update Matomo

### DIFF
--- a/docs/_includes/analytics.html
+++ b/docs/_includes/analytics.html
@@ -1,19 +1,3 @@
-<!-- Fathom - simple website analytics - https://github.com/usefathom/fathom -->
-<script>
-  (function(f, a, t, h, o, m){
-    a[h]=a[h]||function(){
-      (a[h].q=a[h].q||[]).push(arguments)
-    };
-    o=f.createElement('script'),
-    m=f.getElementsByTagName('script')[0];
-    o.async=1; o.src=t; o.id='fathom-script';
-    m.parentNode.insertBefore(o,m)
-  })(document, window, '//fathom-proxy-devex-von-prod.pathfinder.gov.bc.ca/tracker.js', 'fathom');
-  fathom('set', 'siteId', '{{site.analytics.tracking_id}}');
-  fathom('trackPageview');
-  </script>
-<!-- / Fathom -->
-
 <!-- Matomo -->
 <script type="text/javascript">
   var _paq = window._paq || [];
@@ -21,7 +5,7 @@
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {
-    var u="//matomo-devex-von-prod.pathfinder.gov.bc.ca/";
+    var u="//matomo.vonx.io/";
     _paq.push(['setTrackerUrl', u+'matomo.php']);
     _paq.push(['setSiteId', '2']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];


### PR DESCRIPTION
We are going to retire Fathom, so the analytics code is not required anymore.

Matomo will be migrated to a new OpenShift environment, updating the URL to use the `vonx.io` domain in order to retain the functionality across deployments.